### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to v11.6.0
+        run: npm install -g npm@11.6.0
       - run: npm ci
       - name: build binary
         run: npm run buildTS
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![npm version](https://badge.fury.io/js/@masatomakino%2Fcanvas-particle-waypoint.svg)](https://badge.fury.io/js/@masatomakino%2Fcanvas-particle-waypoint)
 [![build](https://github.com/MasatoMakino/canvas-particle-waypoint/actions/workflows/ci_main.yml/badge.svg)](https://github.com/MasatoMakino/canvas-particle-waypoint/actions/workflows/ci_main.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/c29de14e16c38bff2628/test_coverage)](https://codeclimate.com/github/MasatoMakino/canvas-particle-waypoint/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/c29de14e16c38bff2628/maintainability)](https://codeclimate.com/github/MasatoMakino/canvas-particle-waypoint/maintainability)
-
 
 [![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=canvas-particle-waypoint)](https://github.com/MasatoMakino/canvas-particle-waypoint)
 


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication.

## Changes

- ✅ NPM Trusted Publisher configured on npmjs.com
- ✅ Publishing access set to "Require two-factor authentication and disallow tokens"
- ✅ Added OIDC permissions to GitHub Actions workflow
- ✅ Added npm upgrade step for latest OIDC support
- ✅ Removed NPM token authentication from workflow
- ✅ Removed CodeClimate badges and test reporter ID

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

The migration can be tested by creating a release after this PR is merged. The workflow should successfully publish to NPM using Trusted Publisher authentication.

## Important Notes

After merging this PR, the `NPM_PUBLISH_TOKEN` secret should be deleted from repository settings as it will no longer be needed.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline permissions for publishing.
  * Upgraded npm to version 11.6.0 in the publish workflow.
  * Simplified authentication method used during package publication.

* **Documentation**
  * Removed Test Coverage and Maintainability badges from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->